### PR TITLE
Bootstrap improvements

### DIFF
--- a/R/bootstrap_lpi.R
+++ b/R/bootstrap_lpi.R
@@ -37,17 +37,11 @@ bootstrap_lpi <- function(SpeciesLambdaArray, fileindex, DSize, Group, Weighting
 
       # Read SpeciesLambda from saved file FileName = paste('lpi_temp/SpeciesLambda',FileNo,sep='')
       # SpeciesLambda = read.table(FileName, header = FALSE, sep=',')
+      SpeciesLambda = SpeciesLambdaArray[fileindex == FileNo, J]
 
-      SpeciesLambda = SpeciesLambdaArray[fileindex == FileNo, ]
-
-      if (J <= dim(SpeciesLambda)[2]) {
-
-        # If there's still some left to get
-        # Get the lamdas for this pop (species?)
-        SpeciesLambdaVal = SpeciesLambda[, J]
-
+      if(!is.null(SpeciesLambda)) {
         # We shouldn't be sampling missing values....
-        SpeciesLambdaVal = SpeciesLambdaVal[!is.na(SpeciesLambdaVal)]
+        SpeciesLambdaVal = na.omit(SpeciesLambda)
 
         # Get length of lambdas
         n = length(SpeciesLambdaVal)

--- a/R/bootstrap_lpi.R
+++ b/R/bootstrap_lpi.R
@@ -43,14 +43,9 @@ bootstrap_lpi <- function(SpeciesLambdaArray, fileindex, DSize, Group, Weighting
         # We shouldn't be sampling missing values....
         SpeciesLambdaVal = na.omit(SpeciesLambda)
 
-        # Get length of lambdas
-        n = length(SpeciesLambdaVal)
-        # Generate index
-        BootIndex = 1:n
         # Create sample with replacement (single bootstrap instance)
-        BootSam <- sample(BootIndex, replace = T)
-        # Extract lamdas using that sample
-        BootVal = SpeciesLambdaVal[BootSam]
+        BootVal <- sample(SpeciesLambdaVal, replace = T)
+
         # If we've got some meaningful data
         if (!CAP_LAMBDAS) {
           Index = which(BootVal != -1)


### PR DESCRIPTION
This pull request includes a significant performance improvement to the bootstrap process, by avoiding an unnecessary temporary dataframe on line 40 of bootstrap_lpi.R. Profiling showed that this line was previously causing a large amount of memory allocation and dominating CPU time.

In our case, this reduced time taken for 1000 bootstraps from 23s to 5s.

I've also simplified the sampling code to sample `SpeciesLambdaVal` directly instead of sampling a list of indices and looking them up. Any performance improvement from this was marginal.

I have tested that these changes did not affect the final output for our use case, however I should caveat that we do not use multiple input files or groups/weightings etc.