### PR TITLE
Fix Github's linguist so that repo is tagged as R instead of HTML

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+creating_infiles_files/* linguist-documentation
+README.html linguist-documentation


### PR DESCRIPTION
Hello `rlpi` maintainers :wave: !

`rlpi` is currently tagged as an HTML repository by GitHub's Linguist tool (see picture below)
![Capture d’écran 2021-07-08 à 14 27 05](https://user-images.githubusercontent.com/5593751/124921440-b1096b00-dff8-11eb-816f-f578eae5824e.png)

This prevent user to find when searching on GitHub with the `language:R` option.

I've manually tagged the culprit HTML files (`README.html` and HTML files in `creating_infiles_file/` folder) in the `.gitattributes` file. This should solve the problem.

Thanks!